### PR TITLE
[Stage of Stage: Merge Last] Implement Stage of Stage

### DIFF
--- a/src/js/components/ErrorLabel.js
+++ b/src/js/components/ErrorLabel.js
@@ -1,9 +1,6 @@
-/* eslint-disable no-unused-vars */
 import React from 'react';
-/* eslint-enable no-unused-vars */
 
 import APIErrorModal from './APIErrorModal';
-import StoreMap from '../constants/StoreMap';
 import StringUtil from '../utils/StringUtil';
 
 const METHODS_TO_BIND = ['handleErrorClose', 'handleErrorClick'];
@@ -34,23 +31,21 @@ class ErrorLabel extends React.Component {
       return <span>No Errors Found</span>;
     }
 
-    let nodesText = StringUtil.pluralize('Node', errors.length);
+    let errorText = StringUtil.pluralize('Error', errors.length);
 
     return (
       <a className={this.props.className} onClick={this.handleErrorClick}>
-        {`Errors Found on ${errors.length} ${nodesText}`}
+        {`${errors.length} ${errorText}`}
       </a>
     );
   }
 
   render() {
-    let errors = StoreMap[this.props.step].get('errorDetails');
-
     return (
       <div>
-        {this.getErrorLabel(errors)}
+        {this.getErrorLabel(this.props.errors)}
         <APIErrorModal
-          errors={errors}
+          errors={this.props.errors}
           onClose={this.handleErrorClose}
           open={this.state.openErrorModal}
           step={this.props.step} />
@@ -65,6 +60,7 @@ ErrorLabel.defaultProps = {
 
 ErrorLabel.propTypes = {
   className: React.PropTypes.string,
+  errors: React.PropTypes.array,
   step: React.PropTypes.string // preflight, deploy, postflight
 };
 

--- a/src/js/components/ProgressBar.js
+++ b/src/js/components/ProgressBar.js
@@ -1,45 +1,50 @@
 import classnames from 'classnames';
 import React from 'react';
 
-import IconCheckmark from '../components/icons/IconCheckmark';
-import IconWarningSmall from '../components/icons/IconWarningSmall';
+import Timer from '../components/Timer';
 
 class ProgressBar extends React.Component {
   render() {
     let props = this.props;
+    let timer = null;
 
-    let classes = classnames(props.className, props.layoutClassName, {
-      'is-erroneous': props.state === 'error',
-      'is-successful': props.state === 'success'
-    });
+    let {
+      className,
+      errorFillClassName,
+      fillWrapperClassName,
+      headerClassName,
+      label,
+      labelClassName,
+      labelContentClassName,
+      layoutClassName,
+      progress,
+      successFillClassName,
+      timerClassName,
+      timerEnabled
+    } = props;
 
-    let icon = null;
-    let progress = props.progress.toFixed(props.decimalPrecision);
+    let {percentError, percentSuccess} = progress;
+    let classes = classnames(className, layoutClassName);
 
-    if (props.state === 'error') {
-      icon = <IconWarningSmall />;
-    } else if (props.state === 'success') {
-      icon = <IconCheckmark />;
+    if (timerEnabled) {
+      timer = <Timer className={timerClassName} ref="timer" />;
     }
 
     return (
       <div className={classes}>
-        <div className={props.headerClassName}>
-          <span className={props.labelClassName}>
-            {icon}
-            <span className={props.labelContentClassName}>{props.label}</span>
+        <div className={headerClassName}>
+          <span className={labelClassName}>
+            <span className={labelContentClassName}>{label}</span>
           </span>
-          <span className={props.progressClassName}>
-            {`${progress}%`}
-          </span>
+          {timer}
         </div>
-        <div className={props.fillWrapperClassName}>
-          <div className={props.fillClassName} style={{
-            width: `${props.progress}%`
+        <div className={fillWrapperClassName}>
+          <div className={errorFillClassName} style={{
+            width: `${percentError}%`
           }} />
-        </div>
-        <div className={props.detailClassName}>
-          {props.detail}
+          <div className={successFillClassName} style={{
+            width: `${percentSuccess}%`
+          }} />
         </div>
       </div>
     );
@@ -48,34 +53,33 @@ class ProgressBar extends React.Component {
 
 ProgressBar.defaultProps = {
   className: 'progress-bar',
-  decimalPrecision: 0,
   detailClassName: 'progress-bar-detail',
+  errorFillClassName: 'progress-bar-fill progress-bar-fill-error',
   headerClassName: 'progress-bar-header',
-  fillClassName: 'progress-bar-fill',
   fillWrapperClassName: 'progress-bar-fill-wrapper',
   labelClassName: 'progress-bar-label',
   labelContentClassName: 'progress-bar-label-content',
   layoutClassName: '',
   progress: 0,
-  progressClassName: 'progress-bar-progress'
+  successFillClassName: 'progress-bar-fill progress-bar-fill-success',
+  timerClassName: 'progress-bar-timer',
+  timerEnabled: true
 };
 
 ProgressBar.propTypes = {
   className: React.PropTypes.string,
-  decimalPrecision: React.PropTypes.number,
   detail: React.PropTypes.node,
   detailClassName: React.PropTypes.string,
   headerClassName: React.PropTypes.string,
-  fillClassName: React.PropTypes.string,
+  successFillClassName: React.PropTypes.string,
   fillWrapperClassName: React.PropTypes.string,
   label: React.PropTypes.node.isRequired,
   labelClassName: React.PropTypes.string,
   labelContentClassName: React.PropTypes.string,
   layoutClassName: React.PropTypes.string,
-  progress: React.PropTypes.number.isRequired,
-  progressClassName: React.PropTypes.string,
-  precision: React.PropTypes.number,
-  state: React.PropTypes.oneOf(['error', 'ongoing', 'success']).isRequired
+  progress: React.PropTypes.object.isRequired,
+  timerClassName: React.PropTypes.string,
+  timerEnabled: React.PropTypes.bool
 };
 
 module.exports = ProgressBar;

--- a/src/js/components/StageProgress.js
+++ b/src/js/components/StageProgress.js
@@ -1,0 +1,231 @@
+import React from 'react';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+
+import ErrorLabel from '../components/ErrorLabel';
+import IconCircleCheckmark from '../components/icons/IconCircleCheckmark';
+import IconWarning from '../components/icons/IconWarning';
+import InstallerStore from '../stores/InstallerStore';
+import NodesList from '../components/NodesList';
+import Page from '../components/Page';
+import PageContent from '../components/PageContent';
+import PageSection from '../components/PageSection';
+import ProgressBar from '../components/ProgressBar';
+import SectionBody from '../components/SectionBody';
+import SectionHeader from '../components/SectionHeader';
+import SectionHeaderIcon from '../components/SectionHeaderIcon';
+import SectionHeaderPrimary from '../components/SectionHeaderPrimary';
+import SectionHeaderSecondary from '../components/SectionHeaderSecondary';
+import SectionFooter from '../components/SectionFooter';
+import StageActionButtons from '../components/StageActionButtons';
+import StageLinks from '../components/StageLinks';
+import StringUtil from '../utils/StringUtil';
+
+const METHODS_TO_BIND = ['handleDetailsActionClick'];
+
+class StageProgress extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      nodeListOpen: false
+    };
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillMount() {
+    this.props.store.init();
+  }
+
+  componentDidMount() {
+    InstallerStore.setNextStep({
+      enabled: false,
+      label: this.props.nextButtonText,
+      link: null,
+      clickHandler: this.props.nextButtonAction,
+      visible: true
+    });
+  }
+
+  handleDetailsActionClick() {
+    this.setState({nodeListOpen: !this.state.nodeListOpen});
+  }
+
+  handleRetryClick() {
+    this.refs.progressBar.refs.timer.resetTimer();
+    this.props.store.beginStage({retry: true});
+    this.props.store.init();
+  }
+
+  getHeaderIcon(progressState = {}) {
+    if (progressState.completed && progressState.errorCount === 0) {
+      return (
+        <IconCircleCheckmark
+          classNames="icon-padded"
+          key="icon-circle-checkmark" />
+      );
+    }
+
+    if (progressState.completed && progressState.errorCount > 0) {
+      return <IconWarning className="icon-padded" key="icon-warning" />;
+    }
+
+    return this.props.stageIcon;
+  }
+
+  getHeaderContent(progressState = {}) {
+    if (progressState.completed) {
+      if (progressState.failed) {
+        return `${this.props.stateText} Failed`;
+      }
+
+      if (progressState.errorCount > 0) {
+        return `${this.props.stateText} Completed with Errors`;
+      }
+
+      return `${this.props.stateText} Complete`;
+    }
+
+    return this.props.runningText;
+  }
+
+  getProgressBarLabel(progressState = {}) {
+    if (progressState.completed) {
+      return 'Check Complete';
+    }
+
+    let nodeCount = progressState.runningCount;
+    let nodeText = StringUtil.pluralize('Node', nodeCount);
+
+    return (
+      <span>
+        {`Checking ${nodeCount} ${nodeText} `}
+        <span className="progress-bar-label-precentage-complete">
+          ({progressState.percentComplete}% Complete)
+        </span>
+      </span>
+    );
+  }
+
+  render() {
+    let {store} = this.props;
+
+    let completed = store.isCompleted();
+    let detailsAction = 'Show';
+    let errorCount = store.get('errorCount') || 0;
+    let errors = store.get('errorDetails');
+    let failed = store.isFailed();
+    let nodes = store.get('nodes');
+    let runningCount = store.get('runningCount');
+    let successCount = store.get('successCount');
+    let totalHosts = store.get('totalHosts') || 0;
+
+    let percentSuccess = 0;
+    let percentError = 0;
+
+    if (totalHosts !== 0) {
+      percentSuccess = Number((successCount / totalHosts * 100).toFixed(0));
+      percentError = Number((errorCount / totalHosts * 100).toFixed(0));
+    }
+
+    let percentComplete = percentSuccess + percentError;
+
+    if (this.state.nodeListOpen) {
+      detailsAction = 'Hide';
+    }
+
+    let progressBarLabel = this.getProgressBarLabel({
+      completed,
+      runningCount,
+      percentComplete
+    });
+
+    if (completed) {
+      this.refs.progressBar.refs.timer.stopTimer();
+    }
+
+    return (
+      <Page hasNavigationBar={true}>
+        <PageContent>
+          <PageSection>
+            <SectionHeader>
+              <SectionHeaderIcon
+                layoutClassName="section-header-icon-stage-status">
+                <ReactCSSTransitionGroup
+                  transitionAppearTimeout={500}
+                  transitionEnterTimeout={500}
+                  transitionLeaveTimeout={500}
+                  transitionName="section-header-icon">
+                  {this.getHeaderIcon({completed, failed, errorCount})}
+                </ReactCSSTransitionGroup>
+              </SectionHeaderIcon>
+              <SectionHeaderPrimary layoutClassName="flush-bottom flush-top">
+                {this.getHeaderContent({completed, failed, errorCount})}
+              </SectionHeaderPrimary>
+              <SectionHeaderSecondary className="section-header-secondary
+                section-header-secondary-stage-state">
+                <ErrorLabel step={this.props.stageID} errors={errors} />
+              </SectionHeaderSecondary>
+            </SectionHeader>
+            <SectionBody>
+              <ProgressBar
+                label={
+                  <span>
+                    {progressBarLabel}
+                    <span
+                      className="clickable"
+                      onClick={this.handleDetailsActionClick}>
+                      {detailsAction} Details
+                    </span>
+                  </span>
+                }
+                percentComplete={percentComplete}
+                progress={{percentSuccess, percentError}}
+                ref="progressBar" />
+            </SectionBody>
+            <SectionBody>
+              <NodesList nodes={nodes} visible={this.state.nodeListOpen} />
+            </SectionBody>
+          </PageSection>
+          <PageSection>
+            <SectionFooter>
+              <StageActionButtons
+                completed={completed}
+                failed={failed}
+                nextText={this.props.nextStageText}
+                onNextClick={this.props.nextStageAction}
+                onRetryClick={this.handleRetryClick.bind(this)}
+                showDisabled={true}
+                totalErrors={errorCount} />
+            </SectionFooter>
+            <SectionFooter>
+              <StageLinks
+                completed={completed}
+                disabledDisplay={true}
+                failed={failed}
+                stage={this.props.stageID}
+                totalErrors={errorCount} />
+            </SectionFooter>
+          </PageSection>
+        </PageContent>
+      </Page>
+    );
+  }
+}
+
+StageProgress.propTypes = {
+  nextButtonAction: React.PropTypes.func.isRequired,
+  nextButtonText: React.PropTypes.string.isRequired,
+  nextStageAction: React.PropTypes.func.isRequired,
+  nextStageText: React.PropTypes.string.isRequired,
+  router: React.PropTypes.object,
+  runningText: React.PropTypes.string.isRequired,
+  stageIcon: React.PropTypes.node.isRequired,
+  stageID: React.PropTypes.string.isRequired,
+  stateText: React.PropTypes.string.isRequired,
+  store: React.PropTypes.object.isRequired
+};
+
+module.exports = StageProgress;

--- a/src/js/mixins/getActionMixin.js
+++ b/src/js/mixins/getActionMixin.js
@@ -10,34 +10,23 @@ function getActionMixin(stageID) {
 
     getInitialState: function () {
       return {
-        agents: {
-          completed: false,
-          errors: 0,
-          totalRunning: 0,
-          totalStarted: 0,
-          totalAgents: 0
-        },
+        agentCount: 0,
+        agentErrorCount: 0,
+        completed: false,
+        errorCount: 0,
         errorDetails: [],
-        totalHosts: 0,
-        masters: {
-          completed: false,
-          errors: 0,
-          totalRunning: 0,
-          totalStarted: 0,
-          totalMasters: 0
-        }
+        masterCount: 0,
+        masterErrorCount: 0,
+        nodes: [],
+        runningCount: 0,
+        startedCount: 0,
+        successCount: 0,
+        totalHosts: 0
       };
     },
 
     isCompleted: function () {
-      if (!this.get('masters')) {
-        return false;
-      }
-
-      let totalStarted = this.get('masters').totalStarted
-        + this.get('agents').totalStarted;
-      return this.isMasterCompleted() && this.isAgentCompleted()
-       && totalStarted === this.get('totalHosts');
+      return this.get('completed');
     },
 
     isFailed: function () {
@@ -47,29 +36,7 @@ function getActionMixin(stageID) {
         return false;
       }
 
-      return data.masters.errors > 0;
-    },
-
-    isMasterCompleted: function () {
-      let data = this.getSet_data || {};
-
-      if (Object.keys(data).length === 0) {
-        return false;
-      }
-
-      return data.masters.completed && data.masters.totalMasters > 0
-        && data.masters.totalStarted === data.masters.totalMasters;
-    },
-
-    isAgentCompleted: function () {
-      let data = this.getSet_data || {};
-
-      if (Object.keys(data).length === 0) {
-        return false;
-      }
-
-      return data.agents.completed && data.agents.totalAgents > 0
-        && data.agents.totalStarted === data.agents.totalAgents;
+      return this.get('errorCount') > 0;
     }
   };
 }

--- a/src/js/pages/Deploy.js
+++ b/src/js/pages/Deploy.js
@@ -6,28 +6,11 @@ import React from 'react';
 
 import Config from '../config/Config';
 import DeployStore from '../stores/DeployStore';
-import ErrorLabel from '../components/ErrorLabel';
-import IconCircleCheckmark from '../components/icons/IconCircleCheckmark';
-import IconSpinner from '../components/icons/IconSpinner';
-import IconWarning from '../components/icons/IconWarning';
-import InstallerStore from '../stores/InstallerStore';
-import Page from '../components/Page';
-import PageContent from '../components/PageContent';
-import PageSection from '../components/PageSection';
+import IconStageDeploy from '../components/icons/IconStageDeploy';
 import PostFlightStore from '../stores/PostFlightStore';
-import ProgressBar from '../components/ProgressBar';
-import ProgressBarUtil from '../utils/ProgressBarUtil';
-import SectionBody from '../components/SectionBody';
-import SectionHeader from '../components/SectionHeader';
-import SectionHeaderIcon from '../components/SectionHeaderIcon';
-import SectionHeaderPrimary from '../components/SectionHeaderPrimary';
-import SectionHeaderSecondary from '../components/SectionHeaderSecondary';
-import SectionFooter from '../components/SectionFooter';
-import StageActionButtons from '../components/StageActionButtons';
-import StageLinks from '../components/StageLinks';
-import StringUtil from '../utils/StringUtil';
+import StageProgress from '../components/StageProgress';
 
-class Deploy extends mixin(StoreMixin) {
+class Postflight extends mixin(StoreMixin) {
   constructor() {
     super();
 
@@ -37,181 +20,30 @@ class Deploy extends mixin(StoreMixin) {
     ];
   }
 
-  componentWillMount() {
-    DeployStore.init();
-  }
-
-  componentDidMount() {
-    super.componentDidMount();
-    InstallerStore.setNextStep({
-      enabled: false,
-      label: 'Run Post-Flight',
-      link: null,
-      clickHandler: PostFlightStore.beginStage,
-      visible: true
-    });
-  }
-
   onPostFlightStoreBeginSuccess() {
     this.context.router.push('/post-flight');
   }
 
-  handleRetryClick() {
-    DeployStore.beginStage({retry: true});
-    DeployStore.init();
-  }
-
-  getHeaderIcon(completed, failed, totalErrors) {
-    if (completed && totalErrors === 0) {
-      return <IconCircleCheckmark />;
-    }
-
-    if (completed && totalErrors > 0) {
-      return <IconWarning />;
-    }
-
-    return <IconSpinner />;
-  }
-
-  getHeaderContent(completed, failed, totalErrors) {
-    if (completed) {
-      if (failed) {
-        return 'Deploy Failed';
-      }
-
-      if (totalErrors > 0) {
-        return 'Deploy Completed with Errors';
-      }
-
-      return 'Deploy Complete';
-    }
-
-    return `Deploying ${Config.productName}...`;
-  }
-
-  getProgressBarDetail(status, completed, total) {
-    if (completed) {
-      return '';
-    }
-
-    let hostCount = status.totalStarted;
-    return `Deploying ${hostCount} of ${total}`;
-  }
-
-  getProgressBarLabel(type, completed, errors, totalOfType) {
-    if (errors > 0 && completed) {
-      let errorsText = StringUtil.pluralize('Error', errors);
-      let typeText = StringUtil.pluralize(type, totalOfType);
-      return `${errorsText} with ${errors} of ${totalOfType} ${typeText}`;
-    }
-
-    if (completed) {
-      let {errors, totalStarted} = DeployStore.get(`${type.toLowerCase()}s`);
-      let nodeCount = totalStarted - errors;
-
-      if (nodeCount < 0) {
-        nodeCount = 0;
-      }
-
-      let typeText = StringUtil.pluralize(type, nodeCount);
-
-      return `${nodeCount} ${typeText} Check Complete`;
-    }
-
-    return `Deploying to ${type}s`;
-  }
-
-  getProgressBar(type, completed, status, totalOfType) {
-    let progress = ProgressBarUtil.getPercentage(
-      status.totalStarted, totalOfType, type, DeployStore
-    );
-    let state = 'ongoing';
-
-    if (completed && status.errors > 0) {
-      state = 'error';
-    } else if (completed) {
-      state = 'success';
-    }
-
-    return (
-      <ProgressBar
-        detail={this.getProgressBarDetail(status, completed, totalOfType)}
-        label={this.getProgressBarLabel(type, completed, status.errors, totalOfType)}
-        progress={progress} state={state} />
-    );
-  }
-
   render() {
-    let masterStatus = DeployStore.get('masters');
-    let agentStatus = DeployStore.get('agents');
-
-    let completed = DeployStore.isCompleted();
-    let failed = DeployStore.isFailed();
-    let totalErrors = masterStatus.errors + agentStatus.errors;
-    let totalAgents = agentStatus.totalAgents;
-    let totalMasters = masterStatus.totalMasters;
-
     return (
-      <Page hasNavigationBar={true}>
-        <PageContent>
-          <PageSection>
-            <SectionHeader>
-              <SectionHeaderIcon>
-                {this.getHeaderIcon(completed, failed, totalErrors)}
-              </SectionHeaderIcon>
-              <SectionHeaderPrimary>
-                {this.getHeaderContent(completed, failed, totalErrors)}
-              </SectionHeaderPrimary>
-              <SectionHeaderSecondary>
-                <ErrorLabel step="deploy" />
-              </SectionHeaderSecondary>
-            </SectionHeader>
-            <SectionBody>
-              {
-                this.getProgressBar(
-                  'Master',
-                  DeployStore.isMasterCompleted(),
-                  masterStatus,
-                  totalMasters
-                )
-              }
-              {
-                this.getProgressBar(
-                  'Agent',
-                  DeployStore.isAgentCompleted(),
-                  agentStatus,
-                  totalAgents
-                )
-              }
-            </SectionBody>
-          </PageSection>
-          <PageSection>
-            <SectionFooter>
-              <StageActionButtons
-                completed={completed}
-                failed={failed}
-                nextText="Run Post-Flight"
-                onNextClick={PostFlightStore.beginStage.bind(PostFlightStore)}
-                onRetryClick={this.handleRetryClick.bind(this)}
-                showDisabled={true}
-                totalErrors={totalErrors} />
-            </SectionFooter>
-            <SectionFooter>
-              <StageLinks
-                completed={completed}
-                failed={failed}
-                stage="deploy"
-                totalErrors={totalErrors} />
-            </SectionFooter>
-          </PageSection>
-        </PageContent>
-      </Page>
+      <StageProgress
+        nextButtonAction={PostFlightStore.beginStage}
+        nextButtonText="Run Post-Flight"
+        nextStageAction={PostFlightStore.beginStage.bind(PostFlightStore)}
+        nextStageText="Run Post-Flight"
+        router={this.context.router}
+        runningText={`Deploying ${Config.productName}...`}
+        stageIcon={<IconStageDeploy />}
+        stageID="deploy"
+        stateText="Deploy"
+        store={DeployStore}
+        />
     );
   }
 }
 
-Deploy.contextTypes = {
+Postflight.contextTypes = {
   router: React.PropTypes.object
 };
 
-module.exports = Deploy;
+module.exports = Postflight;

--- a/src/js/pages/Postflight.js
+++ b/src/js/pages/Postflight.js
@@ -4,26 +4,10 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 import React from 'react';
 /* eslint-enable no-unused-vars */
 
-import ErrorLabel from '../components/ErrorLabel';
-import IconCircleCheckmark from '../components/icons/IconCircleCheckmark';
-import IconSpinner from '../components/icons/IconSpinner';
-import IconWarning from '../components/icons/IconWarning';
+import IconStagePostflight from '../components/icons/IconStagePostflight';
 import InstallerStore from '../stores/InstallerStore';
-import Page from '../components/Page';
-import PageContent from '../components/PageContent';
-import PageSection from '../components/PageSection';
 import PostFlightStore from '../stores/PostFlightStore';
-import ProgressBar from '../components/ProgressBar';
-import ProgressBarUtil from '../utils/ProgressBarUtil';
-import SectionBody from '../components/SectionBody';
-import SectionHeader from '../components/SectionHeader';
-import SectionHeaderIcon from '../components/SectionHeaderIcon';
-import SectionHeaderPrimary from '../components/SectionHeaderPrimary';
-import SectionHeaderSecondary from '../components/SectionHeaderSecondary';
-import SectionFooter from '../components/SectionFooter';
-import StageActionButtons from '../components/StageActionButtons';
-import StageLinks from '../components/StageLinks';
-import StringUtil from '../utils/StringUtil';
+import StageProgress from '../components/StageProgress';
 
 class Postflight extends mixin(StoreMixin) {
   constructor() {
@@ -34,25 +18,10 @@ class Postflight extends mixin(StoreMixin) {
     ];
   }
 
-  componentWillMount() {
-    super.componentWillMount();
-    PostFlightStore.init();
-  }
-
-  componentDidMount() {
-    super.componentDidMount();
-    InstallerStore.setNextStep({
-      enabled: false,
-      label: 'Continue',
-      link: null,
-      clickHandler: this.goToSuccess.bind(this),
-      visible: true
-    });
-  }
-
-  handleRetryClick() {
-    PostFlightStore.beginStage({retry: true});
-    PostFlightStore.init();
+  onPostFlightStoreStateFinish() {
+    if (PostFlightStore.isCompleted() && !PostFlightStore.isFailed()) {
+      this.goToSuccess();
+    }
   }
 
   goToSuccess() {
@@ -60,162 +29,20 @@ class Postflight extends mixin(StoreMixin) {
     this.context.router.push('/success');
   }
 
-  getHeaderIcon(completed, failed, totalErrors) {
-    if (completed && totalErrors === 0) {
-      return <IconCircleCheckmark />;
-    }
-
-    if (completed && totalErrors > 0) {
-      return <IconWarning />;
-    }
-
-    return <IconSpinner />;
-  }
-
-  getHeaderContent(completed, failed, totalErrors) {
-    if (completed) {
-      if (failed) {
-        return 'Post-Flight Failed';
-      }
-
-      if (totalErrors > 0) {
-        return 'Post-Flight Completed with Errors';
-      }
-
-      return 'Post-Flight Complete';
-    }
-
-    return 'Running Post-Flight...';
-  }
-
-  getProgressBarDetail(status, completed, total) {
-    if (completed) {
-      return '';
-    }
-
-    let hostCount = status.totalStarted;
-    return `Checking ${hostCount} of ${total}`;
-  }
-
-  getProgressBarLabel(type, completed, errors, totalOfType) {
-    if (errors > 0 && completed) {
-      let errorsText = StringUtil.pluralize('Error', errors);
-      let typeText = StringUtil.pluralize(type, totalOfType);
-      return `${errorsText} with ${errors} of ${totalOfType} ${typeText}`;
-    }
-
-    if (completed) {
-      let {errors, totalStarted} = PostFlightStore.get(`${type.toLowerCase()}s`);
-      let nodeCount = totalStarted - errors;
-
-      if (nodeCount < 0) {
-        nodeCount = 0;
-      }
-
-      let typeText = StringUtil.pluralize(type, nodeCount);
-
-      return `${nodeCount} ${typeText} Check Complete`;
-    }
-
-    return `Checking ${type}s`;
-  }
-
-  getProgressBar(type, completed, status, totalOfType) {
-    let progress = ProgressBarUtil.getPercentage(
-      status.totalStarted, totalOfType, type, PostFlightStore
-    );
-    let state = 'ongoing';
-
-    if (completed && status.errors > 0) {
-      state = 'error';
-    } else if (completed) {
-      state = 'success';
-    }
-
-    return (
-      <ProgressBar
-        detail={this.getProgressBarDetail(status, completed, totalOfType)}
-        label={this.getProgressBarLabel(type, completed, status.errors, totalOfType)}
-        progress={progress} state={state} />
-    );
-  }
-
-  onPostFlightStoreStateFinish() {
-    let masterStatus = PostFlightStore.get('masters');
-    let agentStatus = PostFlightStore.get('agents');
-    let totalErrors = masterStatus.errors + agentStatus.errors;
-
-    if (PostFlightStore.isCompleted() && totalErrors === 0) {
-      this.goToSuccess();
-    }
-  }
-
   render() {
-    let masterStatus = PostFlightStore.get('masters');
-    let agentStatus = PostFlightStore.get('agents');
-
-    let completed = PostFlightStore.isCompleted();
-    let failed = PostFlightStore.isFailed();
-    let totalErrors = masterStatus.errors + agentStatus.errors;
-    let totalAgents = agentStatus.totalAgents;
-    let totalMasters = masterStatus.totalMasters;
-
     return (
-      <Page hasNavigationBar={true}>
-        <PageContent>
-          <PageSection>
-            <SectionHeader>
-              <SectionHeaderIcon>
-                {this.getHeaderIcon(completed, failed, totalErrors)}
-              </SectionHeaderIcon>
-              <SectionHeaderPrimary>
-                {this.getHeaderContent(completed, failed, totalErrors)}
-              </SectionHeaderPrimary>
-              <SectionHeaderSecondary>
-                <ErrorLabel step="postflight" />
-              </SectionHeaderSecondary>
-            </SectionHeader>
-            <SectionBody>
-              {
-                this.getProgressBar(
-                  'Master',
-                  PostFlightStore.isMasterCompleted(),
-                  masterStatus,
-                  totalMasters
-                )
-              }
-              {
-                this.getProgressBar(
-                  'Agent',
-                  PostFlightStore.isAgentCompleted(),
-                  agentStatus,
-                  totalAgents
-                )
-              }
-            </SectionBody>
-          </PageSection>
-          <PageSection>
-            <SectionFooter>
-              <StageActionButtons
-                completed={completed}
-                failed={failed}
-                nextText="Continue"
-                onNextClick={this.goToSuccess.bind(this)}
-                onRetryClick={this.handleRetryClick.bind(this)}
-                showDisabled={true}
-                totalErrors={totalErrors} />
-            </SectionFooter>
-            <SectionFooter>
-              <StageLinks
-                completed={completed}
-                disableEditSetup={true}
-                failed={failed}
-                stage="postflight"
-                totalErrors={totalErrors} />
-            </SectionFooter>
-          </PageSection>
-        </PageContent>
-      </Page>
+      <StageProgress
+        nextButtonAction={this.goToSuccess.bind(this)}
+        nextButtonText="Continue"
+        nextStageAction={this.goToSuccess.bind(this)}
+        nextStageText="Continue"
+        router={this.context.router}
+        runningText="Running Post-Flight..."
+        stageIcon={<IconStagePostflight />}
+        stageID="postflight"
+        stateText="Post-Flight"
+        store={PostFlightStore}
+        />
     );
   }
 }

--- a/src/js/pages/Success.js
+++ b/src/js/pages/Success.js
@@ -55,19 +55,12 @@ module.exports = class Success extends mixin(StoreMixin) {
   }
 
   render() {
-    let totalMasters = 0;
-    let totalAgents = 0;
+    let totalAgents = PostFlightStore.get('agentCount')
+      - PostFlightStore.get('agentErrorCount');
+    let totalMasters = PostFlightStore.get('masterCount');
 
-    let masterStatus = PostFlightStore.get('masters');
-    let agentStatus = PostFlightStore.get('agents');
-
-    if (masterStatus != null && agentStatus != null) {
-      totalMasters = masterStatus.totalMasters;
-      totalAgents = agentStatus.totalAgents - agentStatus.errors;
-    }
-
-    let masterNodeText = StringUtil.pluralize('Node', totalMasters);
     let agentNodeText = StringUtil.pluralize('Node', totalAgents);
+    let masterNodeText = StringUtil.pluralize('Node', totalMasters);
 
     return (
       <Page hasNavigationBar={true} pageName="success" size="medium">

--- a/src/js/utils/ProcessStageUtil.js
+++ b/src/js/utils/ProcessStageUtil.js
@@ -1,6 +1,9 @@
 import Config from '../config/Config';
+import NodeStatuses from '../constants/NodeStatuses';
 
-function getStdout(stdout) {
+const DEFAULT_ERROR = 'An unknown error occurred.';
+
+function getErrorsFromStdout(stdout) {
   let failedLines = stdout.filter(function (line) {
     return line.indexOf('FAIL') > -1;
   });
@@ -13,63 +16,92 @@ function getStdout(stdout) {
 }
 
 function getErrors(commands) {
-  var errors = commands.reduce(function (total, cmd) {
-    let stdout = getStdout(cmd.stdout);
+  let errors = commands.reduce(function (total, cmd) {
+    let stdout = getErrorsFromStdout(cmd.stdout);
     let output = stdout.concat(cmd.stderr);
     return total.concat(output.filter(function (line) { return line !== ''}));
   }, []);
 
-  var errorMap = {};
+  let errorMap = {};
 
   errors.forEach(function (line) {
     errorMap[line] = true;
   });
+
+  if (Object.keys(errorMap).length === 0) {
+    return DEFAULT_ERROR;
+  }
+
   return Object.keys(errorMap).join('\n');
 }
 
-function processHostState(hostState, host, role, state) {
-  let stateType = state[`${role}s`];
-  let hostStatus = hostState.host_status;
+function getIPComponents(ip = '') {
+  let colonIndex = ip.indexOf(':');
 
-  stateType.totalStarted += 1;
-
-  if (hostStatus === 'running') {
-    stateType.totalRunning += 1;
-    stateType.completed = false;
+  if (colonIndex === -1) {
+    return {ip, port: null};
   }
 
-  if (hostStatus === 'not_running') {
-    stateType.completed = false;
+  return {
+    ip: ip.substring(0, colonIndex),
+    port: ip.substring(colonIndex + 1, ip.length)
+  };
+}
+
+function processHostState(hostData, host, role, state) {
+  let errors = null;
+  let hostStatus = hostData.host_status;
+  let isCompleted = true;
+  let {ip, port} = getIPComponents(host);
+
+  state.startedCount += 1;
+  state[`${role}Count`] += 1;
+
+  if (hostStatus === NodeStatuses.RUNNING) {
+    state.runningCount += 1;
+    isCompleted = false;
   }
 
-  if (hostStatus === 'failed' || hostStatus === 'terminated') {
-    stateType.errors += 1;
+  if (hostStatus === NodeStatuses.UNSTARTED) {
+    isCompleted = false;
+  }
 
-    var errors = getErrors(hostState.commands, host);
+  if (hostStatus === NodeStatuses.SUCCESS) {
+    state.successCount += 1;
+  }
+
+  if (hostStatus === NodeStatuses.FAILED
+    || hostStatus === NodeStatuses.TERMINATED) {
+    isCompleted = false;
+    errors = getErrors(hostData.commands, host);
+    state.errorCount += 1;
+    state[`${role}ErrorCount`] += 1;
     state.errorDetails.push({host, message: errors});
   }
+
+  state.nodes.push({errors, ip, port, role, status: hostStatus});
+
+  return isCompleted;
 }
 
 const ProcessStageUtil = {
   processState(response) {
     let state = {
-      agents: {
-        completed: true,
-        errors: 0,
-        totalRunning: 0,
-        totalStarted: 0,
-        totalAgents: response.total_agents || 0
-      },
+      agentCount: 0,
+      agentErrorCount: 0,
+      completed: false,
+      errorCount: 0,
       errorDetails: [],
-      totalHosts: response.total_hosts || 0,
-      masters: {
-        completed: true,
-        errors: 0,
-        totalRunning: 0,
-        totalStarted: 0,
-        totalMasters: response.total_masters || 0
-      }
+      masterCount: 0,
+      masterErrorCount: 0,
+      nodes: [],
+      runningCount: 0,
+      startedCount: 0,
+      successCount: 0,
+      totalHosts: response.total_hosts || 0
     };
+
+    let isCompleted = false;
 
     if (Object.keys(response).length === 0) {
       return state;
@@ -81,7 +113,8 @@ const ProcessStageUtil = {
       if (typeof hostStatus !== 'object') {
         return;
       }
-      var role;
+
+      let role;
 
       if (!hostStatus.tags) {
         role = 'agent';
@@ -93,8 +126,10 @@ const ProcessStageUtil = {
         role = 'agent';
       }
 
-      processHostState(hostStatus, host, role, state);
+      isCompleted = processHostState(hostStatus, host, role, state);
     });
+
+    state.completed = isCompleted;
 
     return state;
   },


### PR DESCRIPTION
This implements the changes to the design. We are no longer tracking the status of masters and agents separately, instead they are treated as one unit and will have one progress bar.

Additionally, the API will report status on all nodes, even those that have not yet been touched by the installer. This means the logic around stage completion is greatly simplified.

Because the layout of all three phases are so similar, I created a generic component (`StageProgress`) which is implemented by each of the three phases. The data is collected in the `page` components and passed down to `StageProgress` for display.
