### PR TITLE
Add security dropdown

### DIFF
--- a/src/css/components/tooltips.less
+++ b/src/css/components/tooltips.less
@@ -167,4 +167,8 @@
       color: @tooltip-link-foreground;
     }
   }
+
+  p {
+    color: inherit;
+  }
 }

--- a/src/css/pages/setup.less
+++ b/src/css/pages/setup.less
@@ -25,7 +25,3 @@
     width: 100%;
   }
 }
-
-.form-control[name="ip_detect_script"] {
-  display: none;
-}

--- a/src/js/constants/ConfigFormFields.js
+++ b/src/js/constants/ConfigFormFields.js
@@ -2,6 +2,7 @@ const BACKEND_FORM_FIELDS = [
   'master_list',
   'agent_list',
   'public_agent_list',
+  'security',
   'ssh_user',
   'ssh_port',
   'ssh_key',

--- a/src/js/pages/Setup.js
+++ b/src/js/pages/Setup.js
@@ -456,9 +456,9 @@ class Setup extends mixin(StoreMixin) {
                 <Tooltip
                   content={
                     <span>
-                      <p><b>Permissive:</b> Both authenticated and unauthenticated frameworks are allowed; both encrypted and unencrypted communications are allowed.</p>
-                      <p><b>Strict:</b> Unauthenticated frameworks are rejected; unencrypted communications are rejected; etc.</p>
-                      <p className="flush"><b>Disabled:</b> Encryption and framework authentication are not supported.</p>
+                      <p><strong>Permissive</strong>: Both authenticated and unauthenticated frameworks are allowed; both encrypted and unencrypted communications are allowed.</p>
+                      <p><strong>Strict</strong>: Unauthenticated frameworks are rejected; unencrypted communications are rejected; etc.</p>
+                      <p className="flush"><strong>Disabled</strong>: Encryption and framework authentication are not supported.</p>
                     </span>
                   }
                   tooltipWrapperClassName='tooltip-wrapper'

--- a/src/js/pages/Setup.js
+++ b/src/js/pages/Setup.js
@@ -517,6 +517,7 @@ class Setup extends mixin(StoreMixin) {
         },
         {
           fieldType: 'textarea',
+          inputClass: 'hidden',
           name: 'ip_detect_script',
           placeholder: 'IP Detect Script',
           showLabel: (

--- a/src/js/pages/Setup.js
+++ b/src/js/pages/Setup.js
@@ -53,6 +53,7 @@ const METHODS_TO_BIND = [
   'getValidationFn',
   'handleFormChange',
   'handleIPDetectSelection',
+  'handleSecuritySelection',
   'handleSubmitCancel',
   'handleSubmitClick',
   'handleSubmitConfirm',
@@ -78,6 +79,7 @@ class Setup extends mixin(StoreMixin) {
         ip_detect_script: null,
         public_agent_list: null,
         public_ip_address: global.localStorage.getItem('publicHostname'),
+        security: 'permissive',
         ssh_user: null,
         ssh_port: null,
         ssh_key: null,
@@ -89,6 +91,7 @@ class Setup extends mixin(StoreMixin) {
         agent_list: null,
         public_agent_list: null,
         ip_detect_script: null,
+        security: 'permissive',
         ssh_user: null,
         ssh_port: null,
         ssh_key: null
@@ -439,6 +442,43 @@ class Setup extends mixin(StoreMixin) {
         validation: this.getValidationFn('ssh_key'),
         value: this.state.formData.ssh_key
       },
+      {
+        fieldType: 'textarea',
+        columnWidth: 6,
+        formGroupClass: 'form-group flush-bottom',
+        inputClass: 'hidden',
+        name: 'security',
+        showLabel: (
+          <div>
+            <FormLabel>
+              <FormLabelContent position="left">
+                Security Settings
+                <Tooltip content={
+                    <span>
+                      <b>Permissive:</b><br />Both authenticated and unauthenticated frameworks are allowed; both encrypted and unencrypted communications are allowed.<br />
+                      <b>Strict:</b><br />Unauthenticated frameworks are rejected; unencrypted communications are rejected; etc.<br />
+                      <b>Disabled:</b><br />Encryption and framework authentication are not supported.
+                    </span>
+                  }
+                  width={300} wrapText={true} />
+              </FormLabelContent>
+            </FormLabel>
+            <Dropdown buttonClassName="button dropdown-toggle"
+              dropdownMenuClassName="dropdown-menu"
+              dropdownMenuListClassName="dropdown-menu-list"
+              items={this.getSecurityOptions()}
+              onItemSelection={this.handleSecuritySelection}
+              initialID="dropdown-label"
+              persistentID={this.state.formData.security}
+              transition={false}
+              wrapperClassName="dropdown ip-detect-dropdown"/>
+          </div>
+        ),
+        showError: this.getErrors('security'),
+        validation: this.getValidationFn('security'),
+        validationErrorText: this.getErrors('security'),
+        value: this.state.formData.security
+      },
       <SectionHeader>
         <SectionHeaderPrimary align="left" layoutClassName="short-top flush-bottom">
           {Config.productName} Environment Settings
@@ -586,6 +626,23 @@ class Setup extends mixin(StoreMixin) {
     return _.extend({}, this.state.formData, newFormData);
   }
 
+  getSecurityOptions() {
+    return [
+      {
+        id: 'permissive',
+        html: 'Permissive'
+      },
+      {
+        id: 'strict',
+        html: 'Strict'
+      },
+      {
+        id: 'diabled',
+        html: 'Disabled'
+      }
+    ];
+  }
+
   getUploadHandler(destinationKey, fileType) {
     let localValidationErrors = this.state.localValidationErrors;
 
@@ -710,6 +767,15 @@ class Setup extends mixin(StoreMixin) {
     }
 
     this.setState(state);
+  }
+
+  handleSecuritySelection(selection) {
+    let {id} = selection;
+
+    let change = {security: id};
+    let formData = Object.assign({}, this.state.formData, change);
+    this.submitFormData(change);
+    this.setState({formData});
   }
 
   handleSubmitClick() {

--- a/src/js/pages/Setup.js
+++ b/src/js/pages/Setup.js
@@ -461,7 +461,7 @@ class Setup extends mixin(StoreMixin) {
                       <p className="flush"><strong>Disabled</strong>: Encryption and framework authentication are not supported.</p>
                     </span>
                   }
-                  tooltipWrapperClassName='tooltip-wrapper'
+                  tooltipWrapperClassName="tooltip-wrapper"
                   width={500}
                   wrapText={true} />
               </FormLabelContent>
@@ -641,7 +641,7 @@ class Setup extends mixin(StoreMixin) {
         html: 'Strict'
       },
       {
-        id: 'diabled',
+        id: 'disabled',
         html: 'Disabled'
       }
     ];

--- a/src/js/pages/Setup.js
+++ b/src/js/pages/Setup.js
@@ -453,14 +453,17 @@ class Setup extends mixin(StoreMixin) {
             <FormLabel>
               <FormLabelContent position="left">
                 Security Settings
-                <Tooltip content={
+                <Tooltip
+                  content={
                     <span>
-                      <b>Permissive:</b><br />Both authenticated and unauthenticated frameworks are allowed; both encrypted and unencrypted communications are allowed.<br />
-                      <b>Strict:</b><br />Unauthenticated frameworks are rejected; unencrypted communications are rejected; etc.<br />
-                      <b>Disabled:</b><br />Encryption and framework authentication are not supported.
+                      <p><b>Permissive:</b> Both authenticated and unauthenticated frameworks are allowed; both encrypted and unencrypted communications are allowed.</p>
+                      <p><b>Strict:</b> Unauthenticated frameworks are rejected; unencrypted communications are rejected; etc.</p>
+                      <p className="flush"><b>Disabled:</b> Encryption and framework authentication are not supported.</p>
                     </span>
                   }
-                  width={300} wrapText={true} />
+                  tooltipWrapperClassName='tooltip-wrapper'
+                  width={500}
+                  wrapText={true} />
               </FormLabelContent>
             </FormLabel>
             <Dropdown buttonClassName="button dropdown-toggle"


### PR DESCRIPTION
This PR introduces a security dropdown to the setup page.
Here are images of what the dropdown looks like:
![](https://cl.ly/2a0Q0w3d3X37/Image%202016-08-31%20at%2013.35.40.png)
![](https://cl.ly/242K0g0K3m1E/Image%202016-08-31%20at%2014.00.23.png)

It defaults to `permissive` and sends the data in the format:

``` js
{security: 'permissive'}
```
