### PR TITLE
DCOS-9939: Allow empty form fields

### DIFF
--- a/src/js/pages/Setup.js
+++ b/src/js/pages/Setup.js
@@ -657,7 +657,7 @@ class Setup extends mixin(StoreMixin) {
       this.savePublicURL(fieldValue);
     }
 
-    if (eventType === 'focus' || fieldValue === '' || fieldValue == null) {
+    if (eventType === 'focus') {
       return;
     }
 
@@ -681,19 +681,19 @@ class Setup extends mixin(StoreMixin) {
 
     this.setState(Hooks.applyFilter(
       'handleFormChange', newState, eventDetails
-    ));
-
-    if (this.isFormReady()) {
-      InstallerStore.setNextStep({
-        clickHandler: this.handleSubmitClick,
-        enabled: true
-      });
-    } else {
-      InstallerStore.setNextStep({
-        clickHandler: null,
-        enabled: false
-      });
-    }
+    ), () => {
+      if (this.isFormReady()) {
+        InstallerStore.setNextStep({
+          clickHandler: this.handleSubmitClick,
+          enabled: true
+        });
+      } else {
+        InstallerStore.setNextStep({
+          clickHandler: null,
+          enabled: false
+        });
+      }
+    });
   }
 
   handleIPDetectSelection(selection) {


### PR DESCRIPTION
This PR prevents an early return if the field value is empty.

It also moves the form's readiness check until after state has been updated with the new form data, to prevent the "Next" button from being enabled/disabled erroneously.

cc @rcorral 